### PR TITLE
Fix hardcoded .breeze-block-hero-title icon dimensions

### DIFF
--- a/web/css/abstracts/mixins/_blocks.less
+++ b/web/css/abstracts/mixins/_blocks.less
@@ -120,7 +120,7 @@
 
         & when not (@hero-block-title-icon__mask = false) {
             &::before {
-                .breeze-icon(@hero-block-title-icon__mask, 48px, 9px);
+                .breeze-icon(@hero-block-title-icon__mask, @hero-block-title-icon__width, @hero-block-title-icon__height);
             }
         }
     }


### PR DESCRIPTION
Using an icon with dimensions different from 48x9px results in an unexpected visualization.