### PR TITLE
feat: Sandbox button proposal to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Breeze-based theme.
  - [Demo](https://breeze.swissupdemo.com/breeze_blank/)
  - [Screenshots](https://breezefront.com/screenshots#breeze-blank)
 
+[![Sandbox](https://try.merchantduo.com/_sandbox/button)](https://try.merchantduo.com/_sandbox/setup?template=breeze_blank)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Hello,

I'm runnung this edge-native Magento sandboxes solution, which allows anyone to get 1h TTL fresh Magento env in a glimpse. Would you be interested in giving breeze developers such button, so they could access both admin and code when viewing demo not only shared frontend?

You can also check working button example [there](https://github.com/PerspectiveTeam/NovaposhtaShipping/).

I love breeze for many years and this is my way of giving to the community back. I'm bootstrapped by the edge provider so this service will work undistrupted at lease for a year+ :)

What do you think is this overkill or has mergable potential?